### PR TITLE
Add support for view debugger

### DIFF
--- a/Theodolite/UI/Text/TextKitLayer.swift
+++ b/Theodolite/UI/Text/TextKitLayer.swift
@@ -54,6 +54,10 @@ public final class TextKitLayer: TheodoliteAsyncLayer {
     fatalError("init(coder:) has not been implemented")
   }
 
+  public override init(layer: Any) {
+    super.init(layer: layer)
+  }
+
   public override class func defaultValue(forKey key: String) -> Any? {
     switch key {
     case "contentsScale":


### PR DESCRIPTION
This allows view debugger to create snapshots of the text layers.
Other components might be missing same capability if they are backed by a custom layer

You can see the console spitting out

```
/Users/zats/Documents/GitHawk/Pods/Theodolite/Theodolite/UI/Text/TextKitLayer.swift: 18: 20: Fatal error: Use of unimplemented initializer 'init(layer:)' for class 'Theodolite.TextKitLayer'
2018-02-03 18:59:44.802194-0500 Freetime[16881:6664191] /Users/zats/Documents/GitHawk/Pods/Theodolite/Theodolite/UI/Text/TextKitLayer.swift: 18: 20: Fatal error: Use of unimplemented initializer 'init(layer:)' for class 'Theodolite.TextKitLayer'
```

Before
<img width="553" alt="screen shot 2018-02-03 at 7 00 29 pm" src="https://user-images.githubusercontent.com/2688806/35773015-857bcaa0-0914-11e8-8a2d-f9185afbc43d.png">

After
<img width="550" alt="screen shot 2018-02-03 at 6 58 35 pm" src="https://user-images.githubusercontent.com/2688806/35773016-89fe6dbc-0914-11e8-92f6-4fac2d8e3b20.png">
